### PR TITLE
Fix: App would crash when newVersion is the first version on the phone.

### DIFF
--- a/ADAppRater/ADAppRater.m
+++ b/ADAppRater/ADAppRater.m
@@ -391,7 +391,7 @@ static dispatch_once_t once_token = 0;
     }
     
     // Check if user should be prompted for each version, but with a rate limit
-    else if (self.promptForNewVersionIfUserRated)
+    else if (self.promptForNewVersionIfUserRated && self.userLastPromptedToRate)
     {
         // Check if minimum frequency has passed yet
         NSDateComponents* delta = [[NSCalendar currentCalendar] components:NSCalendarUnitDay


### PR DESCRIPTION
When the "newVersion" is the first version, the application crashes.

Here is the error:
`*** -[__NSCFCalendar components:fromDate:toDate:options:]: fromDate cannot be nil
`
