### PR TITLE
Feature/titles to empty strings

### DIFF
--- a/ADAppRater/Model Layer/ADAppRaterTexts.m
+++ b/ADAppRater/Model Layer/ADAppRaterTexts.m
@@ -68,7 +68,8 @@ static NSString* const kFeedbackFormSubjectLocalKey = @"localFeedbackFormSubject
 
 - (NSString*)userSatisfactionAlertTitle
 {
-    return (_userSatisfactionAlertTitle ? _userSatisfactionAlertTitle : nil);
+    // Empty string if no title to fix Alert controller UI issue
+    return (_userSatisfactionAlertTitle ? _userSatisfactionAlertTitle : @"");
 }
 
 - (NSString*)userSatisfactionAlertMessage;
@@ -116,7 +117,8 @@ static NSString* const kFeedbackFormSubjectLocalKey = @"localFeedbackFormSubject
 
 - (NSString*)userFeedbackAlertTitle
 {
-    return (_userFeedbackAlertTitle ? _userFeedbackAlertTitle : nil);
+    // Empty string if no title to fix Alert controller UI issue
+    return (_userFeedbackAlertTitle ? _userFeedbackAlertTitle : @"");
 }
 
 - (NSString*)userFeedbackAlertMessage

--- a/ADAppRaterTests/Model Object Tests/ADAppRaterTextsTests.m
+++ b/ADAppRaterTests/Model Object Tests/ADAppRaterTextsTests.m
@@ -53,7 +53,7 @@
     XCTAssertEqualObjects(textObject.userSatisfactionAlertMessage, @"Do you find someName useful?");
     XCTAssertEqualObjects(textObject.userSatisfactionAlertAnswerYes, @"Yes");
     XCTAssertEqualObjects(textObject.userSatisfactionAlertAnswerNo, @"No");
-    XCTAssertNil(textObject.userSatisfactionAlertTitle);
+    XCTAssertEqualObjects(textObject.userSatisfactionAlertTitle, @"");
 }
 
 - (void)testAppRater_SatisfactionAlert_CustomTexts
@@ -124,7 +124,7 @@
     ADAppRaterTexts* textObject = [[ADAppRaterTexts alloc] initWithApplicationName:appName feedbackRecipientEmail:@"someMail"];
     
     // Assert
-    XCTAssertNil(textObject.userFeedbackAlertTitle);
+    XCTAssertEqualObjects(textObject.userFeedbackAlertTitle, @"");
     XCTAssertEqualObjects(textObject.userFeedbackAlertMessage, @"Please let us know how to make someName better for you!");
     XCTAssertEqualObjects(textObject.userFeedbackAlertAnswerYes, @"Contact us");
     XCTAssertEqualObjects(textObject.userFeedbackAlertAnswerNo, @"No thanks");


### PR DESCRIPTION
Fix the alert view issue - when setting a nil title the message is bold and close to the top of the view. 
The fix is returning an empty string if no title is set.
