### PR TITLE
Fix link for App Store in iOS 11

### DIFF
--- a/ADAppRater/ADAppStoreConnector.m
+++ b/ADAppRater/ADAppStoreConnector.m
@@ -27,6 +27,7 @@ static NSString *const kARAppLookupURLFormat = @"https://itunes.apple.com/%@/loo
 static NSString *const kARiOSAppStoreURLScheme = @"itms-apps";
 static NSString *const kARiOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=%@&pageNumber=0&sortOrdering=1&onlyLatestVersion=true&action=write-review";
 static NSString *const kARiOS7AppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@";
+static NSString *const kARiOS11AppStoreURLFormat = @"itms-apps://itunes.apple.com/app/apple-store/id%@?mt=8&action=write-review";
 
 #define REQUEST_TIMEOUT 60.0
 
@@ -159,7 +160,11 @@ static NSString *const kARiOS7AppStoreURLFormat = @"itms-apps://itunes.apple.com
         NSString *URLString;
         
         float iOSVersion = [[UIDevice currentDevice].systemVersion floatValue];
-        if (iOSVersion >= 7.0f && iOSVersion < 7.1f)
+        if (iOSVersion >= 11.0f)
+        {
+            URLString = kARiOS11AppStoreURLFormat;
+        }
+        else if (iOSVersion >= 7.0f && iOSVersion < 7.1f)
         {
             URLString = kARiOS7AppStoreURLFormat;
         }


### PR DESCRIPTION
On an iOS 11.0.3 device with an app using ADAppRater 1.1.0, following the prompt to rate the app will result in the App Store opening to a page stating "Cannot Connect To App Store". In the past this would take the user to the Write a Review dialog in the App Store.

On closer inspection, ADAppRater is trying to open this URL (using the Facebook app for example):

[itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=284882215&pageNumber=0&sortOrdering=1&onlyLatestVersion=true&action=write-review](itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=284882215&pageNumber=0&sortOrdering=1&onlyLatestVersion=true&action=write-review)

Changing to this URL will work, taking the user to the app's review page in App Store:

[itms-apps://itunes.apple.com/app/id284882215?mt=8&action=write-review](itms-apps://itunes.apple.com/app/id284882215?mt=8&action=write-review)

The above links can be quickly tested by copy/pasting them into Safari for iOS. (GitHub doesn't want to make these links)

The attached branch attempts to use this URL format when in iOS 11+ and has been tested on an iPhone 6s running iOS 11.0.3.

As this issue prevents users from successfully rating, once approved, I'd like to suggest publishing a new release. 😊