### PR TITLE
add ability for direct route to AppStore

### DIFF
--- a/ADAppRater/ADAppRater.h
+++ b/ADAppRater/ADAppRater.h
@@ -201,6 +201,12 @@
  */
 - (void)promptDirectRatingFromViewController:(__weak UIViewController*)viewController;
 
+/**
+ * Immediately take user to the AppStore ratings page
+ * @discussion No condition is checked
+ */
+-(void)directUserToAppStore;
+
 #pragma mark - Developer Tools
 
 ///---------------------

--- a/ADAppRater/ADAppRater.m
+++ b/ADAppRater/ADAppRater.m
@@ -465,6 +465,14 @@ static dispatch_once_t once_token = 0;
                    });
 }
 
+- (void)directUserToAppStore
+{
+    dispatch_async(dispatch_get_main_queue(), ^
+                   {
+                       [self.appStoreConnector openRatingsPageInAppStore];
+                   });
+}
+
 #ifdef DEBUG
 - (void)resetUsageHistory
 {


### PR DESCRIPTION
This allows you to take a user directly to the ratings page for the app on the AppStore. 